### PR TITLE
Allow Steam to work on non-SteamOS Linux

### DIFF
--- a/src/TrailsHelper/Steam.cs
+++ b/src/TrailsHelper/Steam.cs
@@ -83,7 +83,12 @@ namespace TrailsHelper
             }
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "Steam");
+                var steam_link = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".steam", "steam");
+                if (Directory.Exists(steam_link))
+                {
+                    var steam_dir = Directory.ResolveLinkTarget(steam_link, true);
+                    if (steam_dir is DirectoryInfo info) { return info.FullName; }
+                }
             }
             return null;
         }

--- a/src/TrailsHelper/Steam.cs
+++ b/src/TrailsHelper/Steam.cs
@@ -20,7 +20,7 @@ namespace TrailsHelper
             {
                 // Linux Steam API doesn't like Init with hardcoded int so we use a steam_appid.txt hack.
                 FileStream? steamId = null;
-                if (Steam.IsSteamOS)
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     steamId = File.Open(Path.Combine(Environment.CurrentDirectory, "steam_appid.txt"), new FileStreamOptions()
                     {
@@ -55,19 +55,6 @@ namespace TrailsHelper
             });
         }
 
-        public static bool IsSteamOS
-        {
-            get
-            {
-                // .NET 9 supports 'SteamOS' identifier
-                return RuntimeInformation.OSDescription == "SteamOS"
-                        // Legacy detection (very bad way of checking for SteamOS but we can't use the Steam API at this point)
-                        || (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-                            && RuntimeInformation.OSDescription.Contains("valve")
-                            && RuntimeInformation.OSDescription.Contains("neptune"));
-                    }
-        }
-
         public static string? GetSteamExePath()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -76,7 +63,7 @@ namespace TrailsHelper
                 return key?.GetValue("SteamExe") as string;
             }
 
-            if (Steam.IsSteamOS)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 return "/usr/bin/steam";
             }
@@ -94,7 +81,7 @@ namespace TrailsHelper
                 var key = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Valve\\Steam");
                 return key?.GetValue("SteamPath") as string;
             }
-            if (Steam.IsSteamOS)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "Steam");
             }

--- a/src/TrailsHelper/ViewModels/InstallViewModel.cs
+++ b/src/TrailsHelper/ViewModels/InstallViewModel.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using TrailsHelper.Models;
@@ -173,7 +174,7 @@ namespace TrailsHelper.ViewModels
                 this.DownloadStatus = "Extracting voice data...";
                 await client.ExtractToVoiceFolder(voiceArchive, cancel);
 
-                if (this.IsSteam && Steam.IsSteamOS)
+                if (this.IsSteam && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     this.DownloadStatus = "Setting Proton Launch Arguments...";
                     await client.WriteSteamArgsOnLinux();


### PR DESCRIPTION
I understand that SteamOS is the only officially supported Linux, and that install locations are not 100% standard.
Still, this should work for many Steam installs on Linux, and it seems better to try to find it and fail, than not try at all.